### PR TITLE
Remove undefined return type from getEventById

### DIFF
--- a/app/db/eventStorage.server.ts
+++ b/app/db/eventStorage.server.ts
@@ -13,7 +13,7 @@ export async function getAllEvents(): Promise<Event[]> {
        return events as unknown as  Event[];
 }
 
-export async function getEventById(eventId: string): Promise<Event | undefined> {
+export async function getEventById(eventId: string): Promise<Event> {
     const { db } = await connectDB();
     const events = await db.collection("events").find({}).toArray()
 


### PR DESCRIPTION
The function getEventById no longer returns undefined, ensuring it always returns an Event object. This adjustment simplifies the handling of return values and improves type safety within the codebase.